### PR TITLE
feat(ADH-7683 - vault-credential-provider): add HashiCorp Vault support

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/CredentialProvider.java
@@ -78,6 +78,17 @@ public abstract class CredentialProvider {
   }
 
   /**
+   * Create a new CredentialEntry
+   * @param alias the alias name
+   * @param credential the credential value
+   * @return a new CredentialEntry
+   */
+  protected CredentialEntry newCredentialEntry(String alias,
+      char[] credential) {
+    return new CredentialEntry(alias, credential);
+  }
+
+  /**
    * Indicates whether this provider represents a store
    * that is intended for transient use - such as the UserProvider
    * is. These providers are generally used to provide job access to

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/KerberosVaultAuth.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/KerberosVaultAuth.java
@@ -1,0 +1,224 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.alias.vault;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+import java.security.PrivilegedExceptionAction;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.SecurityUtil;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.ietf.jgss.GSSContext;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.GSSName;
+import org.ietf.jgss.Oid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Kerberos/SPNEGO authentication for Vault.
+ *
+ * <p>Supports two UGI modes via
+ * {@code hadoop.security.credential.vault.kerberos.ugi.mode}:
+ * <ul>
+ *   <li>{@code dedicated} (default) — creates a dedicated UGI from the
+ *       configured principal and keytab.</li>
+ *   <li>{@code current} — uses the current login UGI of the process
+ *       (e.g. NameNode's or Spark driver's own Kerberos identity).
+ *       No separate principal/keytab configuration needed.</li>
+ * </ul>
+ */
+@InterfaceAudience.Private
+public class KerberosVaultAuth implements VaultAuthMethod {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(KerberosVaultAuth.class);
+
+  private static final Oid SPNEGO_OID;
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+
+  static {
+    try {
+      SPNEGO_OID = new Oid("1.3.6.1.5.5.2");
+    } catch (GSSException e) {
+      throw new RuntimeException("Failed to create SPNEGO OID", e);
+    }
+  }
+
+  private final UserGroupInformation vaultUgi;
+  private final VaultConnectionInfo connInfo;
+  private final String loginPath;
+  private final String servicePrincipal;
+
+  /**
+   * Create a Kerberos auth method.
+   *
+   * @param conf the Hadoop configuration
+   * @param connInfo the Vault connection info
+   * @throws IOException if the keytab login fails
+   */
+  public KerberosVaultAuth(Configuration conf,
+      VaultConnectionInfo connInfo) throws IOException {
+    this.connInfo = connInfo;
+    String vaultHost = connInfo.getHost();
+
+    String ugiMode = conf.get(
+        VaultCredentialProviderConfig.KERBEROS_UGI_MODE_KEY,
+        VaultCredentialProviderConfig.KERBEROS_UGI_MODE_DEFAULT);
+
+    if (VaultCredentialProviderConfig.KERBEROS_UGI_MODE_CURRENT
+        .equalsIgnoreCase(ugiMode)) {
+      this.vaultUgi = UserGroupInformation.getCurrentUser();
+      LOG.debug("Using current UGI for Vault Kerberos auth: {}",
+          vaultUgi.getUserName());
+    } else {
+      String principal = conf.get(
+          VaultCredentialProviderConfig.KERBEROS_PRINCIPAL_KEY);
+      String keytab = conf.get(
+          VaultCredentialProviderConfig.KERBEROS_KEYTAB_KEY);
+
+      if (principal == null || principal.isEmpty()) {
+        throw new IOException("Kerberos principal not configured. Set '"
+            + VaultCredentialProviderConfig.KERBEROS_PRINCIPAL_KEY
+            + "' or use ugi.mode=current.");
+      }
+      if (keytab == null || keytab.isEmpty()) {
+        throw new IOException("Kerberos keytab not configured. Set '"
+            + VaultCredentialProviderConfig.KERBEROS_KEYTAB_KEY
+            + "' or use ugi.mode=current.");
+      }
+
+      // Resolve _HOST in client principal to local FQDN
+      String resolvedPrincipal =
+          SecurityUtil.getServerPrincipal(principal, (String) null);
+      this.vaultUgi = UserGroupInformation
+          .loginUserFromKeytabAndReturnUGI(resolvedPrincipal, keytab);
+    }
+
+    this.loginPath = conf.get(
+        VaultCredentialProviderConfig.KERBEROS_LOGIN_PATH_KEY,
+        VaultCredentialProviderConfig.KERBEROS_LOGIN_PATH_DEFAULT);
+
+    // Resolve _HOST in service principal to Vault server hostname
+    String configuredSpn = conf.get(
+        VaultCredentialProviderConfig.KERBEROS_SERVICE_PRINCIPAL_KEY);
+    if (configuredSpn != null && !configuredSpn.isEmpty()) {
+      this.servicePrincipal =
+          SecurityUtil.getServerPrincipal(configuredSpn, vaultHost);
+    } else {
+      this.servicePrincipal =
+          VaultCredentialProviderConfig.KERBEROS_SERVICE_PRINCIPAL_PREFIX_DEFAULT
+              + vaultHost;
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public String authenticate(VaultHttpClient client) throws IOException {
+    try {
+      return vaultUgi.doAs(
+          (PrivilegedExceptionAction<String>) () -> {
+            String spnegoToken = generateSpnegoToken();
+            return loginToVault(client, spnegoToken);
+          });
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Kerberos authentication interrupted", e);
+    }
+  }
+
+  private String generateSpnegoToken() throws IOException {
+    try {
+      GSSManager gssManager = GSSManager.getInstance();
+      GSSName serverName = gssManager.createName(
+          servicePrincipal, GSSName.NT_HOSTBASED_SERVICE);
+      GSSContext gssContext = gssManager.createContext(
+          serverName, SPNEGO_OID, null, GSSContext.DEFAULT_LIFETIME);
+      gssContext.requestMutualAuth(true);
+      gssContext.requestCredDeleg(false);
+
+      byte[] token = gssContext.initSecContext(new byte[0], 0, 0);
+      gssContext.dispose();
+
+      return java.util.Base64.getEncoder().encodeToString(token);
+    } catch (GSSException e) {
+      throw new IOException("Failed to generate SPNEGO token", e);
+    }
+  }
+
+  private String loginToVault(VaultHttpClient client,
+      String spnegoToken) throws IOException {
+    String url = connInfo.getBaseUrl() + "/v1/" + loginPath;
+
+    HttpURLConnection conn = client.createConnection(url, "POST");
+    conn.setRequestProperty("Authorization", "Negotiate " + spnegoToken);
+    conn.setDoOutput(true);
+    conn.setRequestProperty("Content-Type", "application/json");
+    // Empty body for kerberos login
+    try (java.io.OutputStream os = conn.getOutputStream()) {
+      // no content
+    }
+
+    int statusCode = conn.getResponseCode();
+
+    if (statusCode != HttpURLConnection.HTTP_OK) {
+      String errorBody = "";
+      InputStream es = conn.getErrorStream();
+      if (es != null) {
+        try {
+          errorBody = IOUtils.toString(es, StandardCharsets.UTF_8);
+        } finally {
+          es.close();
+        }
+      }
+      conn.disconnect();
+      throw new IOException(
+          "Vault Kerberos login failed with status " + statusCode
+              + ": " + errorBody);
+    }
+
+    String responseBody;
+    try (InputStream is = conn.getInputStream()) {
+      responseBody = IOUtils.toString(is, StandardCharsets.UTF_8);
+    }
+
+    VaultResponse.AuthLogin response = MAPPER.readValue(
+        responseBody, VaultResponse.AuthLogin.class);
+    if (response.auth == null) {
+      throw new IOException(
+          "Vault Kerberos login response missing 'auth' field");
+    }
+    if (response.auth.clientToken == null
+        || response.auth.clientToken.isEmpty()) {
+      throw new IOException(
+          "Vault Kerberos login response missing 'client_token'");
+    }
+
+    LOG.debug("Successfully authenticated to Vault via Kerberos");
+    return response.auth.clientToken;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/TokenVaultAuth.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/TokenVaultAuth.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.alias.vault;
+
+import java.io.IOException;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.conf.Configuration;
+
+/**
+ * Token-based authentication for Vault.
+ * Reads the token from Hadoop configuration, systemd credentials
+ * ({@code $CREDENTIALS_DIRECTORY/vault-token}), or the VAULT_TOKEN
+ * environment variable.
+ */
+@InterfaceAudience.Private
+public class TokenVaultAuth implements VaultAuthMethod {
+
+  private final Configuration conf;
+
+  public TokenVaultAuth(Configuration conf) {
+    this.conf = conf;
+  }
+
+  @Override
+  public String authenticate(VaultHttpClient client) throws IOException {
+    String token = VaultCredentialProviderConfig.resolveToken(conf);
+    if (token == null || token.isEmpty()) {
+      throw new IOException("Vault token not found. Set '"
+          + VaultCredentialProviderConfig.TOKEN_KEY
+          + "' in configuration, provide a systemd credential '"
+          + VaultCredentialProviderConfig.SYSTEMD_CREDENTIAL_NAME_DEFAULT
+          + "' in $" + VaultCredentialProviderConfig.CREDENTIALS_DIRECTORY_ENV
+          + ", or set '" + VaultCredentialProviderConfig.VAULT_TOKEN_ENV
+          + "' environment variable.");
+    }
+    return token;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/VaultAuthMethod.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/VaultAuthMethod.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.alias.vault;
+
+import java.io.IOException;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+
+/**
+ * Interface for Vault authentication methods.
+ */
+@InterfaceAudience.Private
+public interface VaultAuthMethod {
+
+  /**
+   * Authenticate to Vault and return a client token.
+   *
+   * @param client the HTTP client to use for authentication requests
+   * @return the Vault client token
+   * @throws IOException if authentication fails
+   */
+  String authenticate(VaultHttpClient client) throws IOException;
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/VaultConnectionInfo.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/VaultConnectionInfo.java
@@ -1,0 +1,225 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.alias.vault;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.security.ProviderUtils;
+
+/**
+ * Parses a Vault credential provider URI and provides methods to build
+ * Vault API paths.
+ *
+ * URI format: {@code vault://[protocol@]host:port/mount/path}
+ *
+ * Examples:
+ * <ul>
+ *   <li>{@code vault://https@vault.example.com:8200/secret/hadoop/creds}</li>
+ *   <li>{@code vault://http@vault.internal:8200/secret/data-platform}</li>
+ *   <li>{@code vault://vault.example.com:8200/secret/hadoop}</li>
+ * </ul>
+ */
+@InterfaceAudience.Private
+public class VaultConnectionInfo {
+
+  public static final int DEFAULT_PORT = 8200;
+  public static final String DEFAULT_PROTOCOL = "https";
+
+  private final String protocol;
+  private final String host;
+  private final int port;
+  private final String mount;
+  private final String basePath;
+
+  /**
+   * Parse a Vault URI into connection info.
+   *
+   * @param uri the Vault URI
+   * @throws IOException if the URI is invalid
+   */
+  public VaultConnectionInfo(URI uri) throws IOException {
+    String authority = uri.getAuthority();
+    if (authority == null || authority.isEmpty()) {
+      throw new IOException("Invalid Vault URI: missing host in " + uri);
+    }
+
+    if (authority.contains("@")) {
+      // Format: vault://protocol@host:port/...
+      // Use ProviderUtils.unnestUri to extract protocol from authority
+      Path unnested = ProviderUtils.unnestUri(uri);
+      URI innerUri = unnested.toUri();
+
+      String scheme = innerUri.getScheme();
+      this.protocol = (scheme != null && !scheme.isEmpty())
+          ? scheme : DEFAULT_PROTOCOL;
+
+      String innerHost = innerUri.getHost();
+      if (innerHost != null && !innerHost.isEmpty()) {
+        this.host = innerHost;
+        this.port = innerUri.getPort() > 0
+            ? innerUri.getPort() : DEFAULT_PORT;
+      } else {
+        String afterAt = authority.split("@", 2)[1];
+        this.host = parseHost(afterAt);
+        this.port = parsePort(afterAt);
+      }
+    } else {
+      // Format: vault://host:port/...
+      this.protocol = DEFAULT_PROTOCOL;
+      this.host = parseHost(authority);
+      this.port = parsePort(authority);
+    }
+
+    if (this.host == null || this.host.isEmpty()) {
+      throw new IOException("Invalid Vault URI: missing host in " + uri);
+    }
+
+    // Parse path
+    String path = uri.getPath();
+    if (path == null || path.isEmpty()) {
+      throw new IOException("Invalid Vault URI: missing path in " + uri);
+    }
+
+    // Remove leading slash
+    if (path.startsWith("/")) {
+      path = path.substring(1);
+    }
+    // Remove trailing slash
+    if (path.endsWith("/")) {
+      path = path.substring(0, path.length() - 1);
+    }
+
+    if (path.isEmpty()) {
+      throw new IOException(
+          "Invalid Vault URI: path must contain at least a mount point in "
+              + uri);
+    }
+
+    int slashIdx = path.indexOf('/');
+    if (slashIdx < 0) {
+      this.mount = path;
+      this.basePath = null;
+    } else {
+      this.mount = path.substring(0, slashIdx);
+      this.basePath = path.substring(slashIdx + 1);
+    }
+  }
+
+  private static String parseHost(String hostPort) {
+    int colonIdx = hostPort.indexOf(':');
+    if (colonIdx >= 0) {
+      return hostPort.substring(0, colonIdx);
+    }
+    return hostPort;
+  }
+
+  private static int parsePort(String hostPort) {
+    int colonIdx = hostPort.indexOf(':');
+    if (colonIdx >= 0) {
+      try {
+        return Integer.parseInt(hostPort.substring(colonIdx + 1));
+      } catch (NumberFormatException e) {
+        return DEFAULT_PORT;
+      }
+    }
+    return DEFAULT_PORT;
+  }
+
+  /**
+   * Build the data path for a specific alias.
+   * Format: {mount}/data/{basePath}/{alias}
+   *
+   * @param alias the credential alias
+   * @return the Vault data path
+   */
+  public String buildDataPath(String alias) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(mount).append("/data");
+    if (basePath != null && !basePath.isEmpty()) {
+      sb.append('/').append(basePath);
+    }
+    sb.append('/').append(alias);
+    return sb.toString();
+  }
+
+  /**
+   * Build the metadata path for listing.
+   * Format: {mount}/metadata/{basePath}
+   *
+   * @return the Vault metadata path
+   */
+  public String buildMetadataPath() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(mount).append("/metadata");
+    if (basePath != null && !basePath.isEmpty()) {
+      sb.append('/').append(basePath);
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Build the metadata path for a specific alias.
+   * Format: {mount}/metadata/{basePath}/{alias}
+   *
+   * @param alias the credential alias
+   * @return the Vault metadata path for the alias
+   */
+  public String buildMetadataPath(String alias) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(mount).append("/metadata");
+    if (basePath != null && !basePath.isEmpty()) {
+      sb.append('/').append(basePath);
+    }
+    sb.append('/').append(alias);
+    return sb.toString();
+  }
+
+  /**
+   * Get the base URL for the Vault server.
+   * Format: {protocol}://{host}:{port}
+   *
+   * @return the base URL
+   */
+  public String getBaseUrl() {
+    return protocol + "://" + host + ":" + port;
+  }
+
+  public String getProtocol() {
+    return protocol;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public String getMount() {
+    return mount;
+  }
+
+  public String getBasePath() {
+    return basePath;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/VaultCredentialProvider.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/VaultCredentialProvider.java
@@ -1,0 +1,304 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.alias.vault;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.alias.CredentialProvider;
+import org.apache.hadoop.security.alias.CredentialProviderFactory;
+import org.apache.hadoop.thirdparty.com.google.common.cache.Cache;
+import org.apache.hadoop.thirdparty.com.google.common.cache.CacheBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A credential provider backed by HashiCorp Vault or OpenBao KV v2 engine.
+ *
+ * URI format: {@code vault://[protocol@]host:port/mount/path}
+ *
+ * Each alias is stored as a separate secret in Vault at
+ * {@code {mount}/data/{path}/{alias}} with content
+ * {@code {"value": "credential_string"}}.
+ *
+ * <p>The provider maintains two levels of caching within the JVM:
+ * <ul>
+ *   <li><b>Client cache</b> — a static map of {@link VaultHttpClient}
+ *       instances keyed by Vault base URL, so that provider re-creation
+ *       (e.g. repeated {@code Configuration.getPassword()} calls) reuses
+ *       the already-authenticated client.</li>
+ *   <li><b>Credential cache</b> — a Guava {@link Cache} with
+ *       {@code expireAfterWrite} TTL, to avoid repeated HTTP round-trips
+ *       for the same alias within the same JVM.</li>
+ * </ul>
+ *
+ * {@link #flush()} is a no-op. Writes and deletes update the cache
+ * immediately.
+ */
+@InterfaceAudience.Private
+public class VaultCredentialProvider extends CredentialProvider {
+
+  public static final String SCHEME_NAME = "vault";
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(VaultCredentialProvider.class);
+
+  /** Static client cache, lazily initialized on first use. */
+  private static volatile Cache<String, VaultHttpClient> clientCache;
+
+  /** Static credential cache, lazily initialized on first use. */
+  private static volatile Cache<String, String> credentialCache;
+
+  private final URI uri;
+  private final VaultConnectionInfo connInfo;
+  private final VaultHttpClient httpClient;
+  private final boolean cacheEnabled;
+
+  /**
+   * Create a Vault credential provider.
+   *
+   * @param uri the provider URI
+   * @param conf the Hadoop configuration
+   * @throws IOException if the provider cannot be initialized
+   */
+  public VaultCredentialProvider(URI uri, Configuration conf)
+      throws IOException {
+    this.uri = uri;
+    this.connInfo = new VaultConnectionInfo(uri);
+    this.cacheEnabled = conf.getBoolean(
+        VaultCredentialProviderConfig.CACHE_ENABLED_KEY,
+        VaultCredentialProviderConfig.CACHE_ENABLED_DEFAULT);
+
+    initClientCache(conf);
+    if (cacheEnabled) {
+      initCredentialCache(conf);
+    }
+
+    String baseUrl = connInfo.getBaseUrl();
+    try {
+      this.httpClient = clientCache.get(baseUrl, () -> {
+        String authMethodName = conf.get(
+            VaultCredentialProviderConfig.AUTH_METHOD_KEY,
+            VaultCredentialProviderConfig.AUTH_METHOD_DEFAULT);
+        VaultAuthMethod authMethod;
+        if ("kerberos".equalsIgnoreCase(authMethodName)) {
+          authMethod = new KerberosVaultAuth(conf, connInfo);
+        } else {
+          authMethod = new TokenVaultAuth(conf);
+        }
+        return new VaultHttpClient(conf, connInfo, authMethod);
+      });
+    } catch (ExecutionException e) {
+      throw new IOException("Failed to create VaultHttpClient", e.getCause());
+    }
+
+    LOG.debug("Created VaultCredentialProvider for {}", uri);
+  }
+
+  /**
+   * Package-private constructor for testing (no caching).
+   */
+  VaultCredentialProvider(URI uri, VaultConnectionInfo connInfo,
+      VaultHttpClient httpClient) {
+    this.uri = uri;
+    this.connInfo = connInfo;
+    this.httpClient = httpClient;
+    this.cacheEnabled = false;
+  }
+
+  /**
+   * Package-private constructor for testing with cache control.
+   */
+  VaultCredentialProvider(URI uri, VaultConnectionInfo connInfo,
+      VaultHttpClient httpClient, boolean cacheEnabled, long cacheTtlMs) {
+    this.uri = uri;
+    this.connInfo = connInfo;
+    this.httpClient = httpClient;
+    this.cacheEnabled = cacheEnabled;
+    if (cacheEnabled) {
+      credentialCache = CacheBuilder.newBuilder()
+          .expireAfterWrite(cacheTtlMs, TimeUnit.MILLISECONDS)
+          .build();
+    }
+  }
+
+  private static void initClientCache(Configuration conf) {
+    if (clientCache == null) {
+      synchronized (VaultCredentialProvider.class) {
+        if (clientCache == null) {
+          int maxSize = conf.getInt(
+              VaultCredentialProviderConfig.CLIENT_CACHE_MAX_SIZE_KEY,
+              VaultCredentialProviderConfig.CLIENT_CACHE_MAX_SIZE_DEFAULT);
+          clientCache = CacheBuilder.newBuilder()
+              .maximumSize(maxSize)
+              .removalListener(notification -> {
+                VaultHttpClient c =
+                    (VaultHttpClient) notification.getValue();
+                if (c != null) {
+                  c.close();
+                }
+              })
+              .build();
+        }
+      }
+    }
+  }
+
+  private static void initCredentialCache(Configuration conf) {
+    if (credentialCache == null) {
+      synchronized (VaultCredentialProvider.class) {
+        if (credentialCache == null) {
+          long ttlMs = conf.getLong(
+              VaultCredentialProviderConfig.CACHE_TTL_MS_KEY,
+              VaultCredentialProviderConfig.CACHE_TTL_MS_DEFAULT);
+          credentialCache = CacheBuilder.newBuilder()
+              .expireAfterWrite(ttlMs, TimeUnit.MILLISECONDS)
+              .build();
+        }
+      }
+    }
+  }
+
+  @Override
+  public CredentialEntry getCredentialEntry(String alias) throws IOException {
+    if (alias == null || alias.isEmpty()) {
+      return null;
+    }
+    String dataPath = connInfo.buildDataPath(alias);
+
+    if (cacheEnabled) {
+      String cacheKey = buildCacheKey(dataPath);
+      String cached = credentialCache.getIfPresent(cacheKey);
+      if (cached != null) {
+        LOG.debug("Credential cache hit for {}", alias);
+        return newCredentialEntry(alias, cached.toCharArray());
+      }
+    }
+
+    String value = httpClient.readSecret(dataPath);
+    if (value == null) {
+      return null;
+    }
+
+    if (cacheEnabled) {
+      credentialCache.put(buildCacheKey(dataPath), value);
+    }
+    return newCredentialEntry(alias, value.toCharArray());
+  }
+
+  @Override
+  public List<String> getAliases() throws IOException {
+    String metadataPath = connInfo.buildMetadataPath();
+    return httpClient.listSecrets(metadataPath);
+  }
+
+  @Override
+  public CredentialEntry createCredentialEntry(String name, char[] credential)
+      throws IOException {
+    if (name == null || name.isEmpty()) {
+      throw new IOException("Credential alias must not be null or empty");
+    }
+    // Check if already exists
+    CredentialEntry existing = getCredentialEntry(name);
+    if (existing != null) {
+      throw new IOException("Credential " + name
+          + " already exists in " + this);
+    }
+
+    String dataPath = connInfo.buildDataPath(name);
+    String value = new String(credential);
+    httpClient.writeSecret(dataPath, value);
+
+    if (cacheEnabled) {
+      credentialCache.put(buildCacheKey(dataPath), value);
+    }
+    return newCredentialEntry(name, credential);
+  }
+
+  @Override
+  public void deleteCredentialEntry(String name) throws IOException {
+    if (name == null || name.isEmpty()) {
+      throw new IOException("Credential alias must not be null or empty");
+    }
+    // Check if exists
+    CredentialEntry existing = getCredentialEntry(name);
+    if (existing == null) {
+      throw new IOException("Credential " + name
+          + " does not exist in " + this);
+    }
+
+    String metadataPath = connInfo.buildMetadataPath(name);
+    httpClient.deleteSecret(metadataPath);
+
+    if (cacheEnabled) {
+      credentialCache.invalidate(buildCacheKey(connInfo.buildDataPath(name)));
+    }
+  }
+
+  @Override
+  public void flush() throws IOException {
+    // All operations are immediate; nothing to flush.
+  }
+
+  @Override
+  public boolean isTransient() {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return uri.toString();
+  }
+
+  private String buildCacheKey(String path) {
+    return connInfo.getBaseUrl() + "|" + path;
+  }
+
+  /**
+   * Clear all static caches. Package-private, for testing only.
+   */
+  static void clearCaches() {
+    if (clientCache != null) {
+      clientCache.invalidateAll();
+    }
+    if (credentialCache != null) {
+      credentialCache.invalidateAll();
+    }
+  }
+
+  /**
+   * Factory for creating VaultCredentialProvider instances.
+   */
+  public static class Factory extends CredentialProviderFactory {
+
+    @Override
+    public CredentialProvider createProvider(URI providerName,
+        Configuration conf) throws IOException {
+      if (SCHEME_NAME.equals(providerName.getScheme())) {
+        return new VaultCredentialProvider(providerName, conf);
+      }
+      return null;
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/VaultCredentialProviderConfig.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/VaultCredentialProviderConfig.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.alias.vault;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configuration constants for the Vault credential provider.
+ */
+@InterfaceAudience.Private
+public final class VaultCredentialProviderConfig {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(VaultCredentialProviderConfig.class);
+
+  public static final String CONFIG_PREFIX =
+      "hadoop.security.credential.vault.";
+
+  public static final String AUTH_METHOD_KEY =
+      CONFIG_PREFIX + "auth.method";
+  public static final String AUTH_METHOD_DEFAULT = "token";
+
+  public static final String TOKEN_KEY =
+      CONFIG_PREFIX + "token";
+  public static final String VAULT_TOKEN_ENV = "VAULT_TOKEN";
+
+  public static final String CREDENTIALS_DIRECTORY_ENV =
+      "CREDENTIALS_DIRECTORY";
+  public static final String SYSTEMD_CREDENTIAL_NAME_KEY =
+      CONFIG_PREFIX + "systemd.credential.name";
+  public static final String SYSTEMD_CREDENTIAL_NAME_DEFAULT =
+      "vault-token";
+
+  public static final String CONNECTION_TIMEOUT_MS_KEY =
+      CONFIG_PREFIX + "connection.timeout.ms";
+  public static final int CONNECTION_TIMEOUT_MS_DEFAULT = 30000;
+
+  public static final String READ_TIMEOUT_MS_KEY =
+      CONFIG_PREFIX + "read.timeout.ms";
+  public static final int READ_TIMEOUT_MS_DEFAULT = 30000;
+
+  public static final String RETRY_COUNT_KEY =
+      CONFIG_PREFIX + "retry.count";
+  public static final int RETRY_COUNT_DEFAULT = 3;
+
+  public static final String RETRY_INTERVAL_MS_KEY =
+      CONFIG_PREFIX + "retry.interval.ms";
+  public static final int RETRY_INTERVAL_MS_DEFAULT = 1000;
+
+  public static final String KERBEROS_PRINCIPAL_KEY =
+      CONFIG_PREFIX + "kerberos.principal";
+  public static final String KERBEROS_KEYTAB_KEY =
+      CONFIG_PREFIX + "kerberos.keytab";
+  public static final String KERBEROS_LOGIN_PATH_KEY =
+      CONFIG_PREFIX + "kerberos.login.path";
+  public static final String KERBEROS_LOGIN_PATH_DEFAULT =
+      "auth/kerberos";
+
+  public static final String KERBEROS_SERVICE_PRINCIPAL_KEY =
+      CONFIG_PREFIX + "kerberos.service.principal";
+  public static final String KERBEROS_SERVICE_PRINCIPAL_PREFIX_DEFAULT =
+      "HTTP@";
+
+  public static final String KERBEROS_UGI_MODE_KEY =
+      CONFIG_PREFIX + "kerberos.ugi.mode";
+  public static final String KERBEROS_UGI_MODE_DEFAULT = "dedicated";
+  public static final String KERBEROS_UGI_MODE_CURRENT = "current";
+
+  public static final String CACHE_ENABLED_KEY =
+      CONFIG_PREFIX + "cache.enabled";
+  public static final boolean CACHE_ENABLED_DEFAULT = true;
+
+  public static final String CLIENT_CACHE_MAX_SIZE_KEY =
+      CONFIG_PREFIX + "client.cache.max.size";
+  public static final int CLIENT_CACHE_MAX_SIZE_DEFAULT = 16;
+
+  public static final String CACHE_TTL_MS_KEY =
+      CONFIG_PREFIX + "cache.ttl.ms";
+  public static final long CACHE_TTL_MS_DEFAULT = 600000;
+
+  private VaultCredentialProviderConfig() {
+  }
+
+  /**
+   * Resolves the Vault token from configuration, systemd credentials,
+   * or environment variable (in that priority order).
+   *
+   * <p>Resolution order:
+   * <ol>
+   *   <li>Hadoop configuration property {@code hadoop.security.credential.vault.token}</li>
+   *   <li>systemd credential file at {@code $CREDENTIALS_DIRECTORY/<name>}</li>
+   *   <li>Environment variable {@code VAULT_TOKEN}</li>
+   * </ol>
+   *
+   * @param conf the Hadoop configuration
+   * @return the Vault token, or null if not found
+   */
+  public static String resolveToken(Configuration conf) {
+    String token = conf.get(TOKEN_KEY);
+    if (token != null && !token.isEmpty()) {
+      return token;
+    }
+
+    token = readSystemdCredential(conf);
+    if (token != null && !token.isEmpty()) {
+      return token;
+    }
+
+    return System.getenv(VAULT_TOKEN_ENV);
+  }
+
+  /**
+   * Read the Vault token from a systemd credential file.
+   *
+   * @param conf the Hadoop configuration
+   * @return the token string, or null if not available
+   */
+  static String readSystemdCredential(Configuration conf) {
+    return readSystemdCredential(conf,
+        System.getenv(CREDENTIALS_DIRECTORY_ENV));
+  }
+
+  /**
+   * Read the Vault token from a systemd credential file at the given
+   * directory path. Package-private for testability.
+   *
+   * @param conf the Hadoop configuration
+   * @param credDir the credentials directory path, or null if not set
+   * @return the token string, or null if not available
+   */
+  static String readSystemdCredential(Configuration conf, String credDir) {
+    if (credDir == null || credDir.isEmpty()) {
+      return null;
+    }
+
+    String credName = conf.get(SYSTEMD_CREDENTIAL_NAME_KEY,
+        SYSTEMD_CREDENTIAL_NAME_DEFAULT);
+    File credFile = new File(credDir, credName);
+    if (!credFile.isFile()) {
+      LOG.debug("systemd credential file not found: {}", credFile);
+      return null;
+    }
+
+    try (FileInputStream fis = new FileInputStream(credFile)) {
+      String token = IOUtils.toString(fis, StandardCharsets.UTF_8).trim();
+      if (!token.isEmpty()) {
+        LOG.debug("Vault token read from systemd credential: {}", credFile);
+        return token;
+      }
+    } catch (IOException e) {
+      LOG.warn("Failed to read systemd credential file {}: {}",
+          credFile, e.getMessage());
+    }
+    return null;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/VaultHttpClient.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/VaultHttpClient.java
@@ -1,0 +1,355 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.alias.vault;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.ssl.SSLFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * HTTP client for communicating with Vault/OpenBao KV v2 API.
+ * Uses {@link HttpURLConnection} (lightweight, no connection pool)
+ * with configurable timeouts, SSL, retry logic, and automatic
+ * re-authentication on 401/403.
+ */
+@InterfaceAudience.Private
+public class VaultHttpClient implements Closeable {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(VaultHttpClient.class);
+
+  private static final String VAULT_TOKEN_HEADER = "X-Vault-Token";
+  private static final String CONTENT_TYPE_JSON = "application/json";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final VaultAuthMethod authMethod;
+  private final VaultConnectionInfo connInfo;
+  private final int connectTimeoutMs;
+  private final int readTimeoutMs;
+  private final int retryCount;
+  private final int retryIntervalMs;
+  private final SSLFactory sslFactory;
+  private final SSLSocketFactory sslSocketFactory;
+  private volatile String clientToken;
+
+  /**
+   * Create a new VaultHttpClient.
+   *
+   * @param conf the Hadoop configuration
+   * @param connInfo the Vault connection info
+   * @param authMethod the authentication method
+   * @throws IOException if initialization fails
+   */
+  public VaultHttpClient(Configuration conf, VaultConnectionInfo connInfo,
+      VaultAuthMethod authMethod) throws IOException {
+    this.connInfo = connInfo;
+    this.authMethod = authMethod;
+    this.connectTimeoutMs = conf.getInt(
+        VaultCredentialProviderConfig.CONNECTION_TIMEOUT_MS_KEY,
+        VaultCredentialProviderConfig.CONNECTION_TIMEOUT_MS_DEFAULT);
+    this.readTimeoutMs = conf.getInt(
+        VaultCredentialProviderConfig.READ_TIMEOUT_MS_KEY,
+        VaultCredentialProviderConfig.READ_TIMEOUT_MS_DEFAULT);
+    this.retryCount = conf.getInt(
+        VaultCredentialProviderConfig.RETRY_COUNT_KEY,
+        VaultCredentialProviderConfig.RETRY_COUNT_DEFAULT);
+    this.retryIntervalMs = conf.getInt(
+        VaultCredentialProviderConfig.RETRY_INTERVAL_MS_KEY,
+        VaultCredentialProviderConfig.RETRY_INTERVAL_MS_DEFAULT);
+
+    if ("https".equalsIgnoreCase(connInfo.getProtocol())) {
+      this.sslFactory = createSslFactory(conf);
+      try {
+        this.sslSocketFactory = sslFactory.createSSLSocketFactory();
+      } catch (GeneralSecurityException ex) {
+        throw new IOException(
+            "Failed to create SSLSocketFactory for Vault", ex);
+      }
+    } else {
+      this.sslFactory = null;
+      this.sslSocketFactory = null;
+    }
+
+    this.clientToken = authMethod.authenticate(this);
+  }
+
+  VaultHttpClient(VaultConnectionInfo connInfo, VaultAuthMethod authMethod,
+      int connectTimeoutMs, int readTimeoutMs,
+      int retryCount, int retryIntervalMs) throws IOException {
+    this.connInfo = connInfo;
+    this.authMethod = authMethod;
+    this.connectTimeoutMs = connectTimeoutMs;
+    this.readTimeoutMs = readTimeoutMs;
+    this.retryCount = retryCount;
+    this.retryIntervalMs = retryIntervalMs;
+    this.sslFactory = null;
+    this.sslSocketFactory = null;
+    this.clientToken = authMethod.authenticate(this);
+  }
+
+  private static SSLFactory createSslFactory(Configuration conf)
+      throws IOException {
+    SSLFactory factory = new SSLFactory(SSLFactory.Mode.CLIENT, conf);
+    try {
+      factory.init();
+    } catch (GeneralSecurityException ex) {
+      throw new IOException("Failed to initialize SSL for Vault", ex);
+    }
+    return factory;
+  }
+
+  /**
+   * Read a secret value from Vault.
+   *
+   * @param dataPath the KV v2 data path
+   * @return the secret value, or null if not found
+   * @throws IOException if the request fails
+   */
+  public String readSecret(String dataPath) throws IOException {
+    String url = connInfo.getBaseUrl() + "/v1/" + dataPath;
+
+    String responseBody = executeWithRetry("GET", url, null, false);
+    if (responseBody == null) {
+      return null;
+    }
+
+    VaultResponse.KvRead response =
+        MAPPER.readValue(responseBody, VaultResponse.KvRead.class);
+    if (response.data == null || response.data.data == null) {
+      return null;
+    }
+    return response.data.data.get("value");
+  }
+
+  /**
+   * List secrets at the given metadata path.
+   *
+   * @param metadataPath the KV v2 metadata path
+   * @return list of secret names
+   * @throws IOException if the request fails
+   */
+  public List<String> listSecrets(String metadataPath) throws IOException {
+    String url = connInfo.getBaseUrl() + "/v1/" + metadataPath
+        + "?list=true";
+
+    String responseBody = executeWithRetry("GET", url, null, false);
+    if (responseBody == null) {
+      return Collections.emptyList();
+    }
+
+    VaultResponse.KvList response =
+        MAPPER.readValue(responseBody, VaultResponse.KvList.class);
+    if (response.data == null || response.data.keys == null) {
+      return Collections.emptyList();
+    }
+
+    // Filter out directory entries (trailing /)
+    List<String> result = new ArrayList<>();
+    for (String key : response.data.keys) {
+      if (!key.endsWith("/")) {
+        result.add(key);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Write a secret value to Vault.
+   *
+   * @param dataPath the KV v2 data path
+   * @param value the secret value
+   * @throws IOException if the request fails
+   */
+  public void writeSecret(String dataPath, String value) throws IOException {
+    String url = connInfo.getBaseUrl() + "/v1/" + dataPath;
+
+    Map<String, Object> data = new HashMap<>();
+    Map<String, String> innerData = new HashMap<>();
+    innerData.put("value", value);
+    data.put("data", innerData);
+
+    String jsonBody = MAPPER.writeValueAsString(data);
+    executeWithRetry("POST", url, jsonBody, true);
+  }
+
+  /**
+   * Delete a secret from Vault.
+   *
+   * @param metadataPath the KV v2 metadata path for the alias
+   * @throws IOException if the request fails
+   */
+  public void deleteSecret(String metadataPath) throws IOException {
+    String url = connInfo.getBaseUrl() + "/v1/" + metadataPath;
+    executeWithRetry("DELETE", url, null, true);
+  }
+
+  /**
+   * Execute an HTTP request with retry and re-authentication logic.
+   */
+  private String executeWithRetry(String method, String url,
+      String jsonBody, boolean failOnNotFound) throws IOException {
+    IOException lastException = null;
+
+    for (int attempt = 0; attempt <= retryCount; attempt++) {
+      if (attempt > 0) {
+        try {
+          Thread.sleep(retryIntervalMs);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new IOException("Retry interrupted", e);
+        }
+      }
+
+      try {
+        HttpURLConnection conn = createConnection(url, method);
+        conn.setRequestProperty(VAULT_TOKEN_HEADER, clientToken);
+
+        if (jsonBody != null) {
+          conn.setDoOutput(true);
+          conn.setRequestProperty("Content-Type", CONTENT_TYPE_JSON);
+          byte[] bodyBytes = jsonBody.getBytes(StandardCharsets.UTF_8);
+          try (OutputStream os = conn.getOutputStream()) {
+            os.write(bodyBytes);
+          }
+        }
+
+        int statusCode = conn.getResponseCode();
+
+        if (statusCode == HttpURLConnection.HTTP_OK
+            || statusCode == HttpURLConnection.HTTP_NO_CONTENT) {
+          return readResponseBody(conn);
+        }
+
+        if (statusCode == HttpURLConnection.HTTP_NOT_FOUND
+            && !failOnNotFound) {
+          conn.disconnect();
+          return null;
+        }
+
+        if (statusCode == HttpURLConnection.HTTP_UNAUTHORIZED
+            || statusCode == HttpURLConnection.HTTP_FORBIDDEN) {
+          conn.disconnect();
+          LOG.debug("Received {} from Vault, re-authenticating "
+              + "(attempt {}/{})", statusCode, attempt + 1, retryCount + 1);
+          clientToken = authMethod.authenticate(this);
+          continue;
+        }
+
+        String body = readErrorBody(conn);
+        conn.disconnect();
+        throw new IOException("Vault request failed with status "
+            + statusCode + ": " + body);
+
+      } catch (ConnectException | SocketTimeoutException e) {
+        LOG.warn("Vault connection failed (attempt {}/{}): {}",
+            attempt + 1, retryCount + 1, e.getMessage());
+        lastException = e;
+      }
+    }
+
+    throw new IOException(
+        "Vault request failed after " + (retryCount + 1) + " attempts",
+        lastException);
+  }
+
+  /**
+   * Open an HTTP(S) connection to Vault with configured timeouts and SSL.
+   */
+  HttpURLConnection createConnection(String urlString, String method)
+      throws IOException {
+    URL url = new URL(urlString);
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+    conn.setRequestMethod(method);
+    conn.setConnectTimeout(connectTimeoutMs);
+    conn.setReadTimeout(readTimeoutMs);
+    conn.setUseCaches(false);
+
+    if (sslSocketFactory != null && conn instanceof HttpsURLConnection) {
+      HttpsURLConnection httpsConn = (HttpsURLConnection) conn;
+      httpsConn.setSSLSocketFactory(sslSocketFactory);
+      httpsConn.setHostnameVerifier(sslFactory.getHostnameVerifier());
+    }
+
+    return conn;
+  }
+
+  private static String readResponseBody(HttpURLConnection conn)
+      throws IOException {
+    InputStream is = conn.getInputStream();
+    if (is == null) {
+      return null;
+    }
+    try {
+      return IOUtils.toString(is, StandardCharsets.UTF_8);
+    } finally {
+      is.close();
+    }
+  }
+
+  private static String readErrorBody(HttpURLConnection conn) {
+    try {
+      InputStream es = conn.getErrorStream();
+      if (es == null) {
+        return "";
+      }
+      try {
+        return IOUtils.toString(es, StandardCharsets.UTF_8);
+      } finally {
+        es.close();
+      }
+    } catch (IOException e) {
+      return "";
+    }
+  }
+
+  @Override
+  public void close() {
+    if (sslFactory != null) {
+      sslFactory.destroy();
+    }
+  }
+
+  VaultConnectionInfo getConnInfo() {
+    return connInfo;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/VaultResponse.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/VaultResponse.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.alias.vault;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.hadoop.classification.InterfaceAudience;
+
+/**
+ * DTOs for Vault/OpenBao JSON API responses.
+ * All classes use {@code ignoreUnknown = true} so that extra fields
+ * returned by Vault do not cause deserialization failures.
+ */
+@InterfaceAudience.Private
+final class VaultResponse {
+
+  private VaultResponse() {
+  }
+
+  /**
+   * Response from KV v2 read: {@code GET /v1/{mount}/data/{path}}.
+   * <pre>
+   * {"data": {"data": {"value": "secret"}, "metadata": {...}}}
+   * </pre>
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class KvRead {
+    @JsonProperty("data")
+    KvReadData data;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class KvReadData {
+    @JsonProperty("data")
+    Map<String, String> data;
+  }
+
+  /**
+   * Response from KV v2 list: {@code LIST /v1/{mount}/metadata/{path}}.
+   * <pre>
+   * {"data": {"keys": ["key1", "key2", "subdir/"]}}
+   * </pre>
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class KvList {
+    @JsonProperty("data")
+    KvListData data;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class KvListData {
+    @JsonProperty("keys")
+    List<String> keys;
+  }
+
+  /**
+   * Response from auth login (e.g. Kerberos):
+   * {@code POST /v1/auth/kerberos/login}.
+   * <pre>
+   * {"auth": {"client_token": "s.xxxxx", ...}}
+   * </pre>
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class AuthLogin {
+    @JsonProperty("auth")
+    AuthLoginData auth;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static class AuthLoginData {
+    @JsonProperty("client_token")
+    String clientToken;
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/package-info.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/security/alias/vault/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides a Vault/OpenBao backed credential provider for Hadoop.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Unstable
+package org.apache.hadoop.security.alias.vault;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.classification.InterfaceStability;

--- a/hadoop-common-project/hadoop-common/src/main/resources/META-INF/services/org.apache.hadoop.security.alias.CredentialProviderFactory
+++ b/hadoop-common-project/hadoop-common/src/main/resources/META-INF/services/org.apache.hadoop.security.alias.CredentialProviderFactory
@@ -18,3 +18,4 @@ org.apache.hadoop.security.alias.LocalJavaKeyStoreProvider$Factory
 org.apache.hadoop.security.alias.UserProvider$Factory
 org.apache.hadoop.security.alias.BouncyCastleFipsKeyStoreProvider$Factory
 org.apache.hadoop.security.alias.LocalBouncyCastleFipsKeyStoreProvider$Factory
+org.apache.hadoop.security.alias.vault.VaultCredentialProvider$Factory

--- a/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
+++ b/hadoop-common-project/hadoop-common/src/main/resources/core-default.xml
@@ -356,6 +356,160 @@
   </description>
 </property>
 
+<!-- Vault/OpenBao Credential Provider properties -->
+<property>
+  <name>hadoop.security.credential.vault.auth.method</name>
+  <value>token</value>
+  <description>
+    Authentication method for Vault credential provider.
+    Supported values: token, kerberos.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.token</name>
+  <value></value>
+  <description>
+    Vault authentication token. If not set, falls back to systemd
+    credentials ($CREDENTIALS_DIRECTORY/vault-token), then to the
+    VAULT_TOKEN environment variable.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.systemd.credential.name</name>
+  <value>vault-token</value>
+  <description>
+    Name of the systemd credential file containing the Vault token.
+    The file is read from the $CREDENTIALS_DIRECTORY directory
+    set by systemd when using LoadCredential= or SetCredential=.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.ssl.truststore.location</name>
+  <value></value>
+  <description>
+    Path to the SSL truststore for HTTPS connections to Vault.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.ssl.truststore.password</name>
+  <value></value>
+  <description>
+    Password for the Vault SSL truststore.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.connection.timeout.ms</name>
+  <value>30000</value>
+  <description>
+    Connection timeout in milliseconds for Vault HTTP requests.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.read.timeout.ms</name>
+  <value>30000</value>
+  <description>
+    Read timeout in milliseconds for Vault HTTP requests.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.retry.count</name>
+  <value>3</value>
+  <description>
+    Number of retry attempts for failed Vault HTTP requests.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.retry.interval.ms</name>
+  <value>1000</value>
+  <description>
+    Interval in milliseconds between retry attempts for Vault requests.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.kerberos.principal</name>
+  <value></value>
+  <description>
+    Kerberos principal for Vault authentication. Required when
+    hadoop.security.credential.vault.auth.method is set to kerberos.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.kerberos.keytab</name>
+  <value></value>
+  <description>
+    Path to the Kerberos keytab for Vault authentication. Required when
+    hadoop.security.credential.vault.auth.method is set to kerberos.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.kerberos.login.path</name>
+  <value>auth/kerberos</value>
+  <description>
+    Vault auth mount path for Kerberos authentication.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.kerberos.service.principal</name>
+  <value></value>
+  <description>
+    Kerberos service principal for SPNEGO authentication to Vault.
+    If not set, defaults to HTTP@{vault-host}.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.kerberos.ugi.mode</name>
+  <value>dedicated</value>
+  <description>
+    UGI mode for Kerberos authentication to Vault.
+    "dedicated" creates a separate UGI from vault-specific principal/keytab.
+    "current" uses the process's existing login UGI (e.g. NameNode's own
+    Kerberos identity), so no separate principal/keytab is needed.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.cache.enabled</name>
+  <value>true</value>
+  <description>
+    Enable in-JVM caching of credential values read from Vault.
+    When enabled, repeated getPassword() calls return cached values
+    instead of making HTTP requests to Vault.
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.cache.ttl.ms</name>
+  <value>600000</value>
+  <description>
+    Time-to-live in milliseconds for cached credential values.
+    After this period, the next read will fetch a fresh value from Vault.
+    Default is 600000 (10 minutes).
+  </description>
+</property>
+
+<property>
+  <name>hadoop.security.credential.vault.client.cache.max.size</name>
+  <value>16</value>
+  <description>
+    Maximum number of VaultHttpClient instances cached per JVM.
+    Each unique Vault base URL gets its own client. In most deployments
+    this is 1-2.
+  </description>
+</property>
+
 <property>
   <name>hadoop.security.group.mapping.ldap.ssl.truststore</name>
   <value></value>

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/vault/TestVaultConnectionInfo.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/vault/TestVaultConnectionInfo.java
@@ -1,0 +1,165 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.alias.vault;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link VaultConnectionInfo}.
+ */
+public class TestVaultConnectionInfo {
+
+  @Test
+  public void testFullUri() throws Exception {
+    URI uri = new URI("vault://https@vault.example.com:8200/secret/hadoop/creds");
+    VaultConnectionInfo info = new VaultConnectionInfo(uri);
+
+    assertEquals("https", info.getProtocol());
+    assertEquals("vault.example.com", info.getHost());
+    assertEquals(8200, info.getPort());
+    assertEquals("secret", info.getMount());
+    assertEquals("hadoop/creds", info.getBasePath());
+    assertEquals("https://vault.example.com:8200", info.getBaseUrl());
+  }
+
+  @Test
+  public void testHttpProtocol() throws Exception {
+    URI uri = new URI("vault://http@vault.internal:8200/secret/data-platform");
+    VaultConnectionInfo info = new VaultConnectionInfo(uri);
+
+    assertEquals("http", info.getProtocol());
+    assertEquals("vault.internal", info.getHost());
+    assertEquals(8200, info.getPort());
+    assertEquals("secret", info.getMount());
+    assertEquals("data-platform", info.getBasePath());
+    assertEquals("http://vault.internal:8200", info.getBaseUrl());
+  }
+
+  @Test
+  public void testDefaultProtocol() throws Exception {
+    URI uri = new URI("vault://vault.example.com:8200/secret/hadoop");
+    VaultConnectionInfo info = new VaultConnectionInfo(uri);
+
+    assertEquals("vault.example.com", info.getHost());
+    assertEquals(8200, info.getPort());
+    assertEquals("secret", info.getMount());
+    assertEquals("hadoop", info.getBasePath());
+  }
+
+  @Test
+  public void testDefaultPort() throws Exception {
+    URI uri = new URI("vault://https@vault.example.com/secret/hadoop");
+    VaultConnectionInfo info = new VaultConnectionInfo(uri);
+
+    assertEquals("https", info.getProtocol());
+    assertEquals("vault.example.com", info.getHost());
+    assertEquals(VaultConnectionInfo.DEFAULT_PORT, info.getPort());
+    assertEquals("secret", info.getMount());
+  }
+
+  @Test
+  public void testMountOnly() throws Exception {
+    URI uri = new URI("vault://https@vault.example.com:8200/secret");
+    VaultConnectionInfo info = new VaultConnectionInfo(uri);
+
+    assertEquals("secret", info.getMount());
+    assertNull(info.getBasePath());
+  }
+
+  @Test
+  public void testBuildDataPath() throws Exception {
+    URI uri = new URI("vault://https@vault.example.com:8200/secret/hadoop/creds");
+    VaultConnectionInfo info = new VaultConnectionInfo(uri);
+
+    assertEquals("secret/data/hadoop/creds/db.password",
+        info.buildDataPath("db.password"));
+  }
+
+  @Test
+  public void testBuildDataPathMountOnly() throws Exception {
+    URI uri = new URI("vault://https@vault.example.com:8200/secret");
+    VaultConnectionInfo info = new VaultConnectionInfo(uri);
+
+    assertEquals("secret/data/db.password",
+        info.buildDataPath("db.password"));
+  }
+
+  @Test
+  public void testBuildMetadataPath() throws Exception {
+    URI uri = new URI("vault://https@vault.example.com:8200/secret/hadoop/creds");
+    VaultConnectionInfo info = new VaultConnectionInfo(uri);
+
+    assertEquals("secret/metadata/hadoop/creds",
+        info.buildMetadataPath());
+  }
+
+  @Test
+  public void testBuildMetadataPathWithAlias() throws Exception {
+    URI uri = new URI("vault://https@vault.example.com:8200/secret/hadoop/creds");
+    VaultConnectionInfo info = new VaultConnectionInfo(uri);
+
+    assertEquals("secret/metadata/hadoop/creds/db.password",
+        info.buildMetadataPath("db.password"));
+  }
+
+  @Test
+  public void testBuildMetadataPathMountOnly() throws Exception {
+    URI uri = new URI("vault://https@vault.example.com:8200/secret");
+    VaultConnectionInfo info = new VaultConnectionInfo(uri);
+
+    assertEquals("secret/metadata",
+        info.buildMetadataPath());
+  }
+
+  @Test(expected = IOException.class)
+  public void testInvalidUriNoPath() throws Exception {
+    URI uri = new URI("vault://https@vault.example.com:8200");
+    new VaultConnectionInfo(uri);
+  }
+
+  @Test(expected = IOException.class)
+  public void testInvalidUriEmptyPath() throws Exception {
+    URI uri = new URI("vault://https@vault.example.com:8200/");
+    new VaultConnectionInfo(uri);
+  }
+
+  @Test
+  public void testSpecialCharactersInAlias() throws Exception {
+    URI uri = new URI("vault://https@vault.example.com:8200/secret/hadoop");
+    VaultConnectionInfo info = new VaultConnectionInfo(uri);
+
+    assertEquals("secret/data/hadoop/my.special-key_1",
+        info.buildDataPath("my.special-key_1"));
+  }
+
+  @Test
+  public void testTrailingSlashInPath() throws Exception {
+    URI uri = new URI("vault://https@vault.example.com:8200/secret/hadoop/");
+    VaultConnectionInfo info = new VaultConnectionInfo(uri);
+
+    assertEquals("secret", info.getMount());
+    assertEquals("hadoop", info.getBasePath());
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/vault/TestVaultCredentialProvider.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/vault/TestVaultCredentialProvider.java
@@ -1,0 +1,349 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.alias.vault;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.hadoop.security.alias.CredentialProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link VaultCredentialProvider} using mocked VaultHttpClient.
+ */
+public class TestVaultCredentialProvider {
+
+  private static final String TEST_URI =
+      "vault://https@vault.example.com:8200/secret/hadoop/creds";
+  private VaultHttpClient mockClient;
+  private VaultConnectionInfo connInfo;
+  private VaultCredentialProvider provider;
+
+  @Before
+  public void setUp() throws Exception {
+    VaultCredentialProvider.clearCaches();
+    URI uri = new URI(TEST_URI);
+    connInfo = new VaultConnectionInfo(uri);
+    mockClient = mock(VaultHttpClient.class);
+    provider = new VaultCredentialProvider(uri, connInfo, mockClient);
+  }
+
+  @After
+  public void tearDown() {
+    VaultCredentialProvider.clearCaches();
+  }
+
+  @Test
+  public void testGetCredentialEntry() throws Exception {
+    when(mockClient.readSecret("secret/data/hadoop/creds/db.password"))
+        .thenReturn("p@ssw0rd");
+
+    CredentialProvider.CredentialEntry entry =
+        provider.getCredentialEntry("db.password");
+
+    assertNotNull(entry);
+    assertEquals("db.password", entry.getAlias());
+    assertArrayEquals("p@ssw0rd".toCharArray(), entry.getCredential());
+  }
+
+  @Test
+  public void testGetCredentialEntryNotFound() throws Exception {
+    when(mockClient.readSecret("secret/data/hadoop/creds/missing"))
+        .thenReturn(null);
+
+    CredentialProvider.CredentialEntry entry =
+        provider.getCredentialEntry("missing");
+
+    assertNull(entry);
+  }
+
+  @Test
+  public void testGetCredentialEntryNullAlias() throws Exception {
+    assertNull(provider.getCredentialEntry(null));
+  }
+
+  @Test
+  public void testGetCredentialEntryEmptyAlias() throws Exception {
+    assertNull(provider.getCredentialEntry(""));
+  }
+
+  @Test
+  public void testGetAliases() throws Exception {
+    when(mockClient.listSecrets("secret/metadata/hadoop/creds"))
+        .thenReturn(Arrays.asList("key1", "key2", "key3"));
+
+    List<String> aliases = provider.getAliases();
+
+    assertEquals(3, aliases.size());
+    assertTrue(aliases.contains("key1"));
+    assertTrue(aliases.contains("key2"));
+    assertTrue(aliases.contains("key3"));
+  }
+
+  @Test
+  public void testGetAliasesEmpty() throws Exception {
+    when(mockClient.listSecrets("secret/metadata/hadoop/creds"))
+        .thenReturn(Collections.emptyList());
+
+    List<String> aliases = provider.getAliases();
+
+    assertTrue(aliases.isEmpty());
+  }
+
+  @Test
+  public void testCreateCredentialEntry() throws Exception {
+    when(mockClient.readSecret("secret/data/hadoop/creds/new.key"))
+        .thenReturn(null);
+    doNothing().when(mockClient)
+        .writeSecret("secret/data/hadoop/creds/new.key", "secret_value");
+
+    char[] credential = "secret_value".toCharArray();
+    CredentialProvider.CredentialEntry entry =
+        provider.createCredentialEntry("new.key", credential);
+
+    assertNotNull(entry);
+    assertEquals("new.key", entry.getAlias());
+    assertArrayEquals(credential, entry.getCredential());
+    verify(mockClient).writeSecret(
+        "secret/data/hadoop/creds/new.key", "secret_value");
+  }
+
+  @Test
+  public void testCreateCredentialEntryAlreadyExists() throws Exception {
+    when(mockClient.readSecret("secret/data/hadoop/creds/existing"))
+        .thenReturn("old_value");
+
+    try {
+      provider.createCredentialEntry("existing", "new_value".toCharArray());
+      fail("should throw");
+    } catch (IOException e) {
+      assertEquals("Credential existing already exists in " + TEST_URI,
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testCreateCredentialEntryNullAlias() throws Exception {
+    try {
+      provider.createCredentialEntry(null, "value".toCharArray());
+      fail("should throw");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("must not be null or empty"));
+    }
+  }
+
+  @Test
+  public void testCreateCredentialEntryEmptyAlias() throws Exception {
+    try {
+      provider.createCredentialEntry("", "value".toCharArray());
+      fail("should throw");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("must not be null or empty"));
+    }
+  }
+
+  @Test
+  public void testDeleteCredentialEntry() throws Exception {
+    when(mockClient.readSecret("secret/data/hadoop/creds/to.delete"))
+        .thenReturn("some_value");
+    doNothing().when(mockClient)
+        .deleteSecret("secret/metadata/hadoop/creds/to.delete");
+
+    provider.deleteCredentialEntry("to.delete");
+
+    verify(mockClient).deleteSecret("secret/metadata/hadoop/creds/to.delete");
+  }
+
+  @Test
+  public void testDeleteCredentialEntryDoesNotExist() throws Exception {
+    when(mockClient.readSecret("secret/data/hadoop/creds/nonexistent"))
+        .thenReturn(null);
+
+    try {
+      provider.deleteCredentialEntry("nonexistent");
+      fail("should throw");
+    } catch (IOException e) {
+      assertEquals("Credential nonexistent does not exist in " + TEST_URI,
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testDeleteCredentialEntryNullAlias() throws Exception {
+    try {
+      provider.deleteCredentialEntry(null);
+      fail("should throw");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("must not be null or empty"));
+    }
+  }
+
+  @Test
+  public void testIsNotTransient() {
+    assertFalse(provider.isTransient());
+  }
+
+  @Test
+  public void testFlushIsNoOp() throws Exception {
+    provider.flush();
+    // Should not throw
+  }
+
+  @Test
+  public void testToString() {
+    assertEquals(TEST_URI, provider.toString());
+  }
+
+  // --- Credential cache tests ---
+
+  @Test
+  public void testCacheHit() throws Exception {
+    URI uri = new URI(TEST_URI);
+    VaultCredentialProvider cached = new VaultCredentialProvider(
+        uri, connInfo, mockClient, true, 60000);
+
+    when(mockClient.readSecret("secret/data/hadoop/creds/cached.key"))
+        .thenReturn("cached_value");
+
+    // First call - fetches from Vault
+    CredentialProvider.CredentialEntry entry1 =
+        cached.getCredentialEntry("cached.key");
+    assertNotNull(entry1);
+    assertEquals("cached_value",
+        new String(entry1.getCredential()));
+
+    // Second call - should be from cache, no extra HTTP call
+    CredentialProvider.CredentialEntry entry2 =
+        cached.getCredentialEntry("cached.key");
+    assertNotNull(entry2);
+    assertEquals("cached_value",
+        new String(entry2.getCredential()));
+
+    verify(mockClient, times(1))
+        .readSecret("secret/data/hadoop/creds/cached.key");
+  }
+
+  @Test
+  public void testCacheExpiry() throws Exception {
+    URI uri = new URI(TEST_URI);
+    // TTL = 1ms
+    VaultCredentialProvider cached = new VaultCredentialProvider(
+        uri, connInfo, mockClient, true, 1);
+
+    when(mockClient.readSecret("secret/data/hadoop/creds/expiring.key"))
+        .thenReturn("value1")
+        .thenReturn("value2");
+
+    cached.getCredentialEntry("expiring.key");
+
+    // Wait for cache to expire
+    Thread.sleep(10);
+
+    CredentialProvider.CredentialEntry entry2 =
+        cached.getCredentialEntry("expiring.key");
+    assertNotNull(entry2);
+    assertEquals("value2",
+        new String(entry2.getCredential()));
+
+    verify(mockClient, times(2))
+        .readSecret("secret/data/hadoop/creds/expiring.key");
+  }
+
+  @Test
+  public void testCacheInvalidatedOnDelete() throws Exception {
+    URI uri = new URI(TEST_URI);
+    VaultCredentialProvider cached = new VaultCredentialProvider(
+        uri, connInfo, mockClient, true, 60000);
+
+    when(mockClient.readSecret("secret/data/hadoop/creds/del.key"))
+        .thenReturn("value1")
+        .thenReturn(null);
+    doNothing().when(mockClient)
+        .deleteSecret("secret/metadata/hadoop/creds/del.key");
+
+    // Populate cache
+    cached.getCredentialEntry("del.key");
+    // Delete: existence check is a cache hit, then invalidates cache
+    cached.deleteCredentialEntry("del.key");
+    // Next read should go to Vault (cache was cleared by delete)
+    assertNull(cached.getCredentialEntry("del.key"));
+
+    // 2 calls: initial read + post-delete read
+    // (existence check in delete is served from cache)
+    verify(mockClient, times(2))
+        .readSecret("secret/data/hadoop/creds/del.key");
+  }
+
+  @Test
+  public void testCacheUpdatedOnCreate() throws Exception {
+    URI uri = new URI(TEST_URI);
+    VaultCredentialProvider cached = new VaultCredentialProvider(
+        uri, connInfo, mockClient, true, 60000);
+
+    when(mockClient.readSecret("secret/data/hadoop/creds/new.cached"))
+        .thenReturn(null);
+    doNothing().when(mockClient)
+        .writeSecret("secret/data/hadoop/creds/new.cached", "new_val");
+
+    // Create populates cache
+    cached.createCredentialEntry("new.cached", "new_val".toCharArray());
+
+    // Subsequent read should come from cache
+    CredentialProvider.CredentialEntry entry =
+        cached.getCredentialEntry("new.cached");
+    assertNotNull(entry);
+    assertEquals("new_val", new String(entry.getCredential()));
+
+    // Only 1 readSecret call (the existence check in create),
+    // the get after create should be cached
+    verify(mockClient, times(1))
+        .readSecret("secret/data/hadoop/creds/new.cached");
+  }
+
+  @Test
+  public void testCacheDisabled() throws Exception {
+    // provider (from setUp) has cache disabled
+    when(mockClient.readSecret("secret/data/hadoop/creds/no.cache"))
+        .thenReturn("val");
+
+    provider.getCredentialEntry("no.cache");
+    provider.getCredentialEntry("no.cache");
+
+    verify(mockClient, times(2))
+        .readSecret("secret/data/hadoop/creds/no.cache");
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/vault/TestVaultCredentialProviderConfig.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/vault/TestVaultCredentialProviderConfig.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.alias.vault;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Tests for {@link VaultCredentialProviderConfig}, focusing on
+ * systemd credential resolution.
+ */
+public class TestVaultCredentialProviderConfig {
+
+  @Rule
+  public TemporaryFolder tempDir = new TemporaryFolder();
+
+  @Test
+  public void testReadSystemdCredential() throws Exception {
+    File credDir = tempDir.newFolder("credentials");
+    File credFile = new File(credDir, "vault-token");
+    writeFile(credFile, "s.systemd-token-123");
+
+    String token = VaultCredentialProviderConfig.readSystemdCredential(
+        new Configuration(), credDir.getAbsolutePath());
+    assertEquals("s.systemd-token-123", token);
+  }
+
+  @Test
+  public void testReadSystemdCredentialTrimsWhitespace() throws Exception {
+    File credDir = tempDir.newFolder("credentials-trim");
+    File credFile = new File(credDir, "vault-token");
+    writeFile(credFile, "  s.token-with-spaces  \n");
+
+    String token = VaultCredentialProviderConfig.readSystemdCredential(
+        new Configuration(), credDir.getAbsolutePath());
+    assertEquals("s.token-with-spaces", token);
+  }
+
+  @Test
+  public void testReadSystemdCredentialCustomName() throws Exception {
+    File credDir = tempDir.newFolder("credentials-custom");
+    File credFile = new File(credDir, "my-vault-token");
+    writeFile(credFile, "s.custom-name-token");
+
+    Configuration conf = new Configuration();
+    conf.set(VaultCredentialProviderConfig.SYSTEMD_CREDENTIAL_NAME_KEY,
+        "my-vault-token");
+
+    String token = VaultCredentialProviderConfig.readSystemdCredential(
+        conf, credDir.getAbsolutePath());
+    assertEquals("s.custom-name-token", token);
+  }
+
+  @Test
+  public void testReadSystemdCredentialMissingFile() throws Exception {
+    File credDir = tempDir.newFolder("credentials-missing");
+    // Don't create the file
+
+    String token = VaultCredentialProviderConfig.readSystemdCredential(
+        new Configuration(), credDir.getAbsolutePath());
+    assertNull(token);
+  }
+
+  @Test
+  public void testReadSystemdCredentialEmptyFile() throws Exception {
+    File credDir = tempDir.newFolder("credentials-empty");
+    File credFile = new File(credDir, "vault-token");
+    writeFile(credFile, "");
+
+    String token = VaultCredentialProviderConfig.readSystemdCredential(
+        new Configuration(), credDir.getAbsolutePath());
+    assertNull(token);
+  }
+
+  @Test
+  public void testReadSystemdCredentialNoCredentialsDirectory()
+      throws Exception {
+    // CREDENTIALS_DIRECTORY not set (null)
+    String token = VaultCredentialProviderConfig.readSystemdCredential(
+        new Configuration(), null);
+    assertNull(token);
+  }
+
+  @Test
+  public void testConfigTokenTakesPriority() throws Exception {
+    Configuration conf = new Configuration();
+    conf.set(VaultCredentialProviderConfig.TOKEN_KEY, "s.config-token");
+
+    String token = VaultCredentialProviderConfig.resolveToken(conf);
+    assertEquals("s.config-token", token);
+  }
+
+  private static void writeFile(File file, String content)
+      throws IOException {
+    try (FileOutputStream fos = new FileOutputStream(file)) {
+      fos.write(content.getBytes(StandardCharsets.UTF_8));
+    }
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/vault/TestVaultCredentialProviderIntegration.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/vault/TestVaultCredentialProviderIntegration.java
@@ -1,0 +1,320 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.alias.vault;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.io.IOUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.alias.CredentialProvider;
+import org.apache.hadoop.security.alias.CredentialProviderFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Integration tests for VaultCredentialProvider using a mock Vault HTTP server.
+ * Tests the full stack including discovery via CredentialProviderFactory.
+ */
+public class TestVaultCredentialProviderIntegration {
+
+  private static final String TEST_TOKEN = "s.integrationtest";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private HttpServer server;
+  private int port;
+  private Configuration conf;
+
+  /** In-memory store simulating Vault KV v2. */
+  private final ConcurrentHashMap<String, String> store =
+      new ConcurrentHashMap<>();
+
+  @Before
+  public void setUp() throws Exception {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    port = server.getAddress().getPort();
+
+    // Handle all requests under /v1/secret/
+    server.createContext("/v1/secret/", this::handleVaultRequest);
+    server.start();
+
+    VaultCredentialProvider.clearCaches();
+
+    conf = new Configuration();
+    String providerUri =
+        "vault://http@localhost:" + port + "/secret/hadoop/creds";
+    conf.set(CredentialProviderFactory.CREDENTIAL_PROVIDER_PATH, providerUri);
+    conf.set(VaultCredentialProviderConfig.TOKEN_KEY, TEST_TOKEN);
+    conf.setInt(VaultCredentialProviderConfig.RETRY_COUNT_KEY, 0);
+    // Disable credential cache so integration tests see fresh Vault state
+    conf.setBoolean(VaultCredentialProviderConfig.CACHE_ENABLED_KEY, false);
+
+    store.clear();
+  }
+
+  @After
+  public void tearDown() {
+    if (server != null) {
+      server.stop(0);
+    }
+    VaultCredentialProvider.clearCaches();
+  }
+
+  @Test
+  public void testDiscoveryViaFactory() throws Exception {
+    List<CredentialProvider> providers =
+        CredentialProviderFactory.getProviders(conf);
+
+    assertEquals(1, providers.size());
+    assertTrue(providers.get(0) instanceof VaultCredentialProvider);
+  }
+
+  @Test
+  public void testCrudLifecycle() throws Exception {
+    List<CredentialProvider> providers =
+        CredentialProviderFactory.getProviders(conf);
+    CredentialProvider provider = providers.get(0);
+
+    // Initially no entry
+    assertNull(provider.getCredentialEntry("test.key"));
+
+    // Create
+    char[] password = "mySecret123".toCharArray();
+    CredentialProvider.CredentialEntry entry =
+        provider.createCredentialEntry("test.key", password);
+    assertNotNull(entry);
+    assertArrayEquals(password, entry.getCredential());
+
+    // Read back
+    entry = provider.getCredentialEntry("test.key");
+    assertNotNull(entry);
+    assertArrayEquals(password, entry.getCredential());
+
+    // List
+    List<String> aliases = provider.getAliases();
+    assertTrue(aliases.contains("test.key"));
+
+    // Duplicate create should fail
+    try {
+      provider.createCredentialEntry("test.key", "other".toCharArray());
+      fail("should throw");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("already exists"));
+    }
+
+    // Delete
+    provider.deleteCredentialEntry("test.key");
+    assertNull(provider.getCredentialEntry("test.key"));
+
+    // Delete non-existent should fail
+    try {
+      provider.deleteCredentialEntry("test.key");
+      fail("should throw");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("does not exist"));
+    }
+  }
+
+  @Test
+  public void testConfigurationGetPassword() throws Exception {
+    // Pre-populate the store
+    store.put("hadoop/creds/ssl.password", "keystorePass");
+
+    char[] password = conf.getPassword("ssl.password");
+    assertNotNull(password);
+    assertArrayEquals("keystorePass".toCharArray(), password);
+  }
+
+  @Test
+  public void testMultipleCredentials() throws Exception {
+    List<CredentialProvider> providers =
+        CredentialProviderFactory.getProviders(conf);
+    CredentialProvider provider = providers.get(0);
+
+    provider.createCredentialEntry("key1", "value1".toCharArray());
+    provider.createCredentialEntry("key2", "value2".toCharArray());
+    provider.createCredentialEntry("key3", "value3".toCharArray());
+
+    List<String> aliases = provider.getAliases();
+    assertEquals(3, aliases.size());
+    assertTrue(aliases.contains("key1"));
+    assertTrue(aliases.contains("key2"));
+    assertTrue(aliases.contains("key3"));
+
+    assertArrayEquals("value1".toCharArray(),
+        provider.getCredentialEntry("key1").getCredential());
+    assertArrayEquals("value2".toCharArray(),
+        provider.getCredentialEntry("key2").getCredential());
+    assertArrayEquals("value3".toCharArray(),
+        provider.getCredentialEntry("key3").getCredential());
+  }
+
+  @SuppressWarnings("unchecked")
+  private void handleVaultRequest(HttpExchange exchange) {
+    try {
+      String path = exchange.getRequestURI().getPath();
+      String method = exchange.getRequestMethod();
+      String token = exchange.getRequestHeaders().getFirst("X-Vault-Token");
+
+      if (!TEST_TOKEN.equals(token)) {
+        sendResponse(exchange, 403,
+            "{\"errors\":[\"permission denied\"]}");
+        return;
+      }
+
+      // Strip /v1/secret/ prefix
+      String subPath = path.substring("/v1/secret/".length());
+
+      if (subPath.startsWith("data/")) {
+        String key = subPath.substring("data/".length());
+        handleDataRequest(exchange, method, key);
+      } else if (subPath.startsWith("metadata/")) {
+        String key = subPath.substring("metadata/".length());
+        handleMetadataRequest(exchange, method, key);
+      } else {
+        sendResponse(exchange, 404, "{\"errors\":[\"not found\"]}");
+      }
+    } catch (Exception e) {
+      try {
+        sendResponse(exchange, 500,
+            "{\"errors\":[\"" + e.getMessage() + "\"]}");
+      } catch (Exception ignored) {
+      }
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private void handleDataRequest(HttpExchange exchange, String method,
+      String key) throws Exception {
+    if ("GET".equals(method)) {
+      String value = store.get(key);
+      if (value == null) {
+        sendResponse(exchange, 404, "{\"errors\":[\"not found\"]}");
+      } else {
+        Map<String, Object> response = new HashMap<>();
+        Map<String, Object> data = new HashMap<>();
+        Map<String, String> innerData = new HashMap<>();
+        innerData.put("value", value);
+        data.put("data", innerData);
+        response.put("data", data);
+        sendResponse(exchange, 200, MAPPER.writeValueAsString(response));
+      }
+    } else if ("POST".equals(method)) {
+      String body = new String(
+          IOUtils.toByteArray(exchange.getRequestBody()),
+              StandardCharsets.UTF_8);
+      Map<String, Object> request = MAPPER.readValue(body, Map.class);
+      Map<String, String> data = (Map<String, String>) request.get("data");
+      String value = data.get("value");
+      store.put(key, value);
+      sendResponse(exchange, 200, "{\"data\":{\"version\":1}}");
+    } else {
+      sendResponse(exchange, 405, "{\"errors\":[\"method not allowed\"]}");
+    }
+  }
+
+  private void handleMetadataRequest(HttpExchange exchange, String method,
+      String key) throws Exception {
+    if ("DELETE".equals(method)) {
+      store.remove(key);
+      sendResponse(exchange, 204, "");
+    } else if ("GET".equals(method)) {
+      // LIST operation (with ?list=true query parameter)
+      String query = exchange.getRequestURI().getQuery();
+      if (query != null && query.contains("list=true")) {
+        // List all keys under the prefix
+        String prefix = key.endsWith("/") ? key : key + "/";
+        // Handle case where key might not have trailing / yet
+        java.util.List<String> keys = new java.util.ArrayList<>();
+        for (String storedKey : store.keySet()) {
+          if (storedKey.startsWith(prefix)) {
+            String remainder = storedKey.substring(prefix.length());
+            // Only return the first segment
+            int slashIdx = remainder.indexOf('/');
+            String entry = slashIdx >= 0
+                ? remainder.substring(0, slashIdx + 1) : remainder;
+            if (!keys.contains(entry)) {
+              keys.add(entry);
+            }
+          }
+        }
+        if (keys.isEmpty()) {
+          // Also check without trailing slash prefix
+          String altPrefix = key;
+          for (String storedKey : store.keySet()) {
+            if (storedKey.startsWith(altPrefix + "/")
+                || storedKey.equals(altPrefix)) {
+              String remainder = storedKey.equals(altPrefix)
+                  ? storedKey
+                  : storedKey.substring(altPrefix.length() + 1);
+              int slashIdx = remainder.indexOf('/');
+              String entry = slashIdx >= 0
+                  ? remainder.substring(0, slashIdx + 1) : remainder;
+              if (!keys.contains(entry) && !entry.isEmpty()) {
+                keys.add(entry);
+              }
+            }
+          }
+        }
+        if (keys.isEmpty()) {
+          sendResponse(exchange, 404, "{\"errors\":[\"not found\"]}");
+        } else {
+          Map<String, Object> response = new HashMap<>();
+          Map<String, Object> data = new HashMap<>();
+          data.put("keys", keys);
+          response.put("data", data);
+          sendResponse(exchange, 200, MAPPER.writeValueAsString(response));
+        }
+      } else {
+        sendResponse(exchange, 404, "{\"errors\":[\"not found\"]}");
+      }
+    } else {
+      sendResponse(exchange, 405, "{\"errors\":[\"method not allowed\"]}");
+    }
+  }
+
+  private void sendResponse(HttpExchange exchange, int statusCode,
+      String body) throws Exception {
+    byte[] responseBytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.sendResponseHeaders(statusCode,
+        responseBytes.length > 0 ? responseBytes.length : -1);
+    if (responseBytes.length > 0) {
+      try (OutputStream os = exchange.getResponseBody()) {
+        os.write(responseBytes);
+      }
+    }
+    exchange.close();
+  }
+}

--- a/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/vault/TestVaultHttpClient.java
+++ b/hadoop-common-project/hadoop-common/src/test/java/org/apache/hadoop/security/alias/vault/TestVaultHttpClient.java
@@ -1,0 +1,245 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.security.alias.vault;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.io.IOUtils;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for {@link VaultHttpClient} using an embedded HTTP server.
+ */
+public class TestVaultHttpClient {
+
+  private static final String TEST_TOKEN = "s.testtoken12345";
+
+  private HttpServer server;
+  private int port;
+  private VaultHttpClient client;
+  private VaultConnectionInfo connInfo;
+
+  @Before
+  public void setUp() throws Exception {
+    server = HttpServer.create(new InetSocketAddress(0), 0);
+    port = server.getAddress().getPort();
+
+    URI uri = new URI("vault://http@localhost:" + port + "/secret/hadoop");
+    connInfo = new VaultConnectionInfo(uri);
+
+    VaultAuthMethod auth = c -> TEST_TOKEN;
+
+    server.start();
+    client = new VaultHttpClient(connInfo, auth, 5000, 5000, 1, 100);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (server != null) {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  public void testReadSecret() throws Exception {
+    server.createContext("/v1/secret/data/hadoop/db.password",
+        exchange -> {
+          assertTokenHeader(exchange);
+          String response =
+              "{\"data\":{\"data\":{\"value\":\"p@ssw0rd\"}}}";
+          sendResponse(exchange, 200, response);
+        });
+
+    String value = client.readSecret("secret/data/hadoop/db.password");
+    assertEquals("p@ssw0rd", value);
+  }
+
+  @Test
+  public void testReadSecretNotFound() throws Exception {
+    server.createContext("/v1/secret/data/hadoop/missing",
+        exchange -> {
+          assertTokenHeader(exchange);
+          sendResponse(exchange, 404, "");
+        });
+
+    String value = client.readSecret("secret/data/hadoop/missing");
+    assertNull(value);
+  }
+
+  @Test
+  public void testWriteSecret() throws Exception {
+    final boolean[] called = {false};
+    server.createContext("/v1/secret/data/hadoop/new.key",
+        exchange -> {
+          assertTokenHeader(exchange);
+          assertEquals("POST", exchange.getRequestMethod());
+          String body = new String(
+              IOUtils.toByteArray(exchange.getRequestBody()),
+              StandardCharsets.UTF_8);
+          assertTrue(body.contains("\"value\":\"secret123\""));
+          called[0] = true;
+          sendResponse(exchange, 200,
+              "{\"data\":{\"version\":1}}");
+        });
+
+    client.writeSecret("secret/data/hadoop/new.key", "secret123");
+    assertTrue("Write handler should have been called", called[0]);
+  }
+
+  @Test
+  public void testListSecrets() throws Exception {
+    server.createContext("/v1/secret/metadata/hadoop",
+        exchange -> {
+          assertTokenHeader(exchange);
+          String query = exchange.getRequestURI().getQuery();
+          assertTrue(query != null && query.contains("list=true"));
+          String response =
+              "{\"data\":{\"keys\":[\"key1\",\"key2\",\"subdir/\"]}}";
+          sendResponse(exchange, 200, response);
+        });
+
+    List<String> keys = client.listSecrets("secret/metadata/hadoop");
+    assertEquals(2, keys.size());
+    assertTrue(keys.contains("key1"));
+    assertTrue(keys.contains("key2"));
+  }
+
+  @Test
+  public void testListSecretsNotFound() throws Exception {
+    server.createContext("/v1/secret/metadata/hadoop",
+        exchange -> {
+          sendResponse(exchange, 404, "");
+        });
+
+    List<String> keys = client.listSecrets("secret/metadata/hadoop");
+    assertTrue(keys.isEmpty());
+  }
+
+  @Test
+  public void testDeleteSecret() throws Exception {
+    final boolean[] called = {false};
+    server.createContext("/v1/secret/metadata/hadoop/old.key",
+        exchange -> {
+          assertTokenHeader(exchange);
+          assertEquals("DELETE", exchange.getRequestMethod());
+          called[0] = true;
+          sendResponse(exchange, 204, "");
+        });
+
+    client.deleteSecret("secret/metadata/hadoop/old.key");
+    assertTrue("Delete handler should have been called", called[0]);
+  }
+
+  @Test
+  public void testReauthOn403() throws Exception {
+    AtomicInteger callCount = new AtomicInteger(0);
+    String newToken = "s.newtoken";
+
+    VaultAuthMethod auth = new VaultAuthMethod() {
+      private int authCount = 0;
+      @Override
+      public String authenticate(VaultHttpClient c) {
+        return authCount++ == 0 ? TEST_TOKEN : newToken;
+      }
+    };
+
+    server.createContext("/v1/secret/data/hadoop/auth.test",
+        exchange -> {
+          int count = callCount.incrementAndGet();
+          if (count == 1) {
+            sendResponse(exchange, 403, "{\"errors\":[\"permission denied\"]}");
+          } else {
+            assertEquals(newToken,
+                exchange.getRequestHeaders().getFirst("X-Vault-Token"));
+            sendResponse(exchange, 200,
+                "{\"data\":{\"data\":{\"value\":\"secret\"}}}");
+          }
+        });
+
+    VaultHttpClient reauthClient =
+        new VaultHttpClient(connInfo, auth, 5000, 5000, 2, 100);
+    String value = reauthClient.readSecret("secret/data/hadoop/auth.test");
+    assertEquals("secret", value);
+    assertTrue("Should have retried after 403", callCount.get() >= 2);
+  }
+
+  @Test
+  public void testTokenHeader() throws Exception {
+    server.createContext("/v1/secret/data/hadoop/check.token",
+        exchange -> {
+          String token = exchange.getRequestHeaders()
+              .getFirst("X-Vault-Token");
+          assertEquals(TEST_TOKEN, token);
+          sendResponse(exchange, 200,
+              "{\"data\":{\"data\":{\"value\":\"ok\"}}}");
+        });
+
+    String value = client.readSecret("secret/data/hadoop/check.token");
+    assertEquals("ok", value);
+  }
+
+  @Test
+  public void testServerError() throws Exception {
+    server.createContext("/v1/secret/data/hadoop/error.key",
+        exchange -> {
+          sendResponse(exchange, 500, "{\"errors\":[\"internal error\"]}");
+        });
+
+    try {
+      client.readSecret("secret/data/hadoop/error.key");
+      fail("should throw IOException");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("500"));
+    }
+  }
+
+  private void assertTokenHeader(HttpExchange exchange) {
+    String token = exchange.getRequestHeaders().getFirst("X-Vault-Token");
+    assertNotNull("X-Vault-Token header must be present", token);
+  }
+
+  private void sendResponse(HttpExchange exchange, int statusCode,
+      String body) throws IOException {
+    byte[] responseBytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.sendResponseHeaders(statusCode,
+        responseBytes.length > 0 ? responseBytes.length : -1);
+    if (responseBytes.length > 0) {
+      try (OutputStream os = exchange.getResponseBody()) {
+        os.write(responseBytes);
+      }
+    }
+    exchange.close();
+  }
+}


### PR DESCRIPTION
The Vault Credential Provider integrates HashiCorp Vault and OpenBao with Hadoop's CredentialProvider API. It allows Hadoop components to retrieve passwords, secrets, and other sensitive tokens directly from Vault's KV v2 secrets engine instead of storing them in Java KeyStore files or configuration XML.

This is useful for organizations that already use Vault as a centralized secrets management solution and want Hadoop to consume secrets from the same source of truth.